### PR TITLE
Use self iso window so the library can be used in a worker.

### DIFF
--- a/src/cuid.js
+++ b/src/cuid.js
@@ -35,7 +35,7 @@ function safeCounter() {
 const cache = (function calc() {
   let count = 0;
 
-  for (const i in window) {
+  for (const i in self) {
     count++;
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ import initSync from './poll_sync_protocol';
 import initConnectionStatus from './connection_status';
 import serverComm from './server_comm';
 
-const { isOnline, onlineStatusChanged } = initConnectionStatus(window);
+const { isOnline, onlineStatusChanged } = initConnectionStatus(self);
 
 const sync = initSync(serverComm, isOnline);
 


### PR DESCRIPTION
Fix for using the library in a worker where window is not defined causing an error to be thrown when the SyncClient is loaded.